### PR TITLE
fix: correct session ID in --summary output

### DIFF
--- a/replay.cs
+++ b/replay.cs
@@ -956,6 +956,11 @@ JsonlData? ParseJsonlData(string path)
     string sessionId = "", branch = "", copilotVersion = "", cwd = "";
     DateTimeOffset? startTime = null, endTime = null;
 
+    // Derive session ID from directory name (Copilot session-state uses {guid}/events.jsonl)
+    var dirName = Path.GetFileName(Path.GetDirectoryName(path));
+    if (!string.IsNullOrEmpty(dirName) && Guid.TryParse(dirName, out _))
+        sessionId = dirName;
+
     foreach (var ev in events)
     {
         var root = ev.RootElement;


### PR DESCRIPTION
Closes #7

**Bug:** `--summary` showed the wrong session ID (e.g., `3cf0c7ad-95eb-4a4c-8aaf-91fdbdbd6a10`) instead of the actual session ID from the file path.

**Root cause:** `ParseJsonlData` extracted the session ID from the first JSONL event's `id` field (splitting on `.`). This event-level ID can differ from the actual session directory name — for example after session resume, or when event IDs use a different GUID scheme.

**Fix:** Derive the session ID from the parent directory name first (Copilot session-state uses `{guid}/events.jsonl`), falling back to event ID extraction for non-session files. This matches how `LaunchResume` already correctly resolves the session ID.

All 35 existing tests pass.
