### PR TITLE
fix: extract skill names for skills_invoked (#9)

### DIFF
--- a/replay.cs
+++ b/replay.cs
@@ -3053,8 +3053,8 @@ void OutputSummary(JsonlData d, bool asJson)
                             toolUsage[toolName] = toolUsage.GetValueOrDefault(toolName) + 1;
                             
                             // Detect skill invocations
-                            if (toolName == "skill" && tr.TryGetProperty("args", out var args) 
-                                && args.TryGetProperty("skill", out var skillNameEl))
+                            if (toolName == "skill" && tr.TryGetProperty("arguments", out var arguments) 
+                                && arguments.TryGetProperty("skill", out var skillNameEl))
                             {
                                 skillsInvoked.Add(skillNameEl.GetString() ?? "");
                             }

--- a/tests/SummaryOutputTests.cs
+++ b/tests/SummaryOutputTests.cs
@@ -252,7 +252,7 @@ public class SummaryOutputTests
                     toolRequests = new[] {
                         new {
                             name = "skill",
-                            args = new { skill = "ci-analysis" }
+                            arguments = new { skill = "ci-analysis" }
                         }
                     }
                 }


### PR DESCRIPTION
Closes #9

Extracts the skill parameter from tool calls where tool_name is 'skill' to populate the skills_invoked field in summary output.