### PR TITLE
ci: harden GitHub Actions against supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait a few days before adopting a new release so a compromised
+    # action version isn't pulled in the instant it's published.
+    cooldown:
+      default-days: 7
     groups:
       github-owned-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-owned-actions:
+        patterns:
+          - "actions/*"
+          - "github/*"
+    # Third-party actions (e.g. NuGet/*, zizmorcore/*) are intentionally
+    # left ungrouped so each SHA bump gets its own reviewable PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -14,9 +17,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
       - name: Build

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,47 @@
+name: Action Pin Check
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [main, master]
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-pinned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Ensure all action references are pinned to a 40-char commit SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r -d '' file; do
+            # Strip comments, then find `uses:` lines that reference a remote action.
+            while IFS= read -r line; do
+              ref="${line#*@}"          # everything after the first @
+              ref="${ref%% *}"          # drop trailing inline comment / whitespace
+              if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                echo "::error file=$file::Unpinned action reference (must be a 40-char commit SHA): ${line## }"
+                fail=1
+              fi
+            done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^.][^ ]+@' "$file" \
+                       | sed 's/#.*$//' \
+                       | grep -vE 'uses:[[:space:]]*\./' || true)
+          done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+
+          if [[ "$fail" -ne 0 ]]; then
+            echo ""
+            echo "Pin every action to a full commit SHA, e.g.:"
+            echo "  uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1"
+            exit 1
+          fi
+          echo "All action references in .github/workflows are SHA-pinned. ✅"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish Tool
 
 permissions:
+  contents: read
   id-token: write
 
 on:
@@ -14,14 +15,16 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Get version from tag
         id: tag_name
         run: echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
 
@@ -41,7 +44,7 @@ jobs:
         run: dotnet pack dotnet-replay.csproj -c Release -o nupkg /p:Version=${{ steps.tag_name.outputs.current_version }}
 
       - name: NuGet login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -24,10 +24,12 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Ralph — Check for squad work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');
@@ -249,7 +251,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,10 +14,12 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');
@@ -116,7 +118,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,10 +13,12 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -15,10 +15,12 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: Zizmor (Actions security)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/zizmor.yml"
+  push:
+    branches: [main, master]
+    paths:
+      - ".github/workflows/**"
+      - ".github/zizmor.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Enforce SHA-pinning (unpinned-uses) and other real findings, but
+          # don't fail CI on informational notes or low-confidence findings.
+          # Accepted exceptions live in .github/zizmor.yml.
+          min-severity: low
+          min-confidence: medium
+          # Avoid requiring GitHub Advanced Security / code-scanning upload.
+          advanced-security: false
+          config: .github/zizmor.yml
+          online-audits: "false"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+# zizmor static-analysis configuration (https://docs.zizmor.sh/configuration/)
+rules:
+  excessive-permissions:
+    ignore:
+      # publish.yml legitimately needs id-token: write for trusted publishing
+      # (NuGet/login OIDC). contents: read remains the floor for the job.
+      - publish.yml


### PR DESCRIPTION
Mitigates the active tag-hijacking / unpinned-action exploit class by hardening every workflow. Mirrors the vetted pattern from `helix.mcp`.

## Changes
- **SHA-pin** every action to a full 40-char commit (`actions/checkout`, `actions/setup-dotnet`, `actions/github-script`, `NuGet/login`).
- **`persist-credentials: false`** on all checkouts — `GITHUB_TOKEN` is no longer left on disk for later steps.
- **Least-privilege `permissions:`**:
  - `ci.yml` → `contents: read`
  - `publish.yml` → `contents: read` (keeps `id-token: write` for OIDC publish)
- **`zizmor.yml`** workflow + `.github/zizmor.yml` config — static-analysis gate for Actions security.
- **`pin-check.yml`** — fails CI if any action reference is not SHA-pinned.
- **`dependabot.yml`** — weekly action bumps; github-owned grouped, third-party individually reviewable.

## Verification
- Local pin-check guard: all references pinned ✅
- YAML validates ✅
- `zizmor 1.25.2`: **No findings** (low severity / medium confidence; 3 expected ignores for `publish.yml` OIDC permission)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>